### PR TITLE
Fix TypeError when a wrapped block legitimately returns null

### DIFF
--- a/Plugin/View/BlockPlugin.php
+++ b/Plugin/View/BlockPlugin.php
@@ -24,7 +24,14 @@ class BlockPlugin
     ) {
     }
 
-    public function aroundToHtml(AbstractBlock $subject, Closure $proceed): ?string
+    /**
+     * Magento's own AbstractBlock::toHtml() declares no return type, and some blocks rely on
+     * that to return false or null instead of a string. Matching that contract exactly, rather
+     * than guessing which falsy values are legitimate, is what keeps this plugin transparent.
+     *
+     * @return string|false|null
+     */
+    public function aroundToHtml(AbstractBlock $subject, Closure $proceed)
     {
         if (!$this->manager->isCollecting()) {
             return $proceed();

--- a/Plugin/View/BlockPlugin.php
+++ b/Plugin/View/BlockPlugin.php
@@ -24,7 +24,7 @@ class BlockPlugin
     ) {
     }
 
-    public function aroundToHtml(AbstractBlock $subject, Closure $proceed): string
+    public function aroundToHtml(AbstractBlock $subject, Closure $proceed): ?string
     {
         if (!$this->manager->isCollecting()) {
             return $proceed();


### PR DESCRIPTION
## Problem

`BlockPlugin::aroundToHtml()` declares a strict return type on the value it
passes through from `$proceed()`. Magento's own `AbstractBlock::toHtml()` has
no return type declared (only a `@return string` docblock, not enforced by
PHP), and several blocks rely on that to legitimately return something other
than a non-empty string from `_toHtml()`:

* `Mirasvit\SeoMarkup\Block\Og\AbstractBlock::_toHtml(): ?string` returns
  `null` when there's nothing to render (e.g. no Twitter card config).
* `Mirasvit\SeoMarkup\Block\Rs\Searchbox::_toHtml()` returns `false` when no
  search box type is configured (`@return string|false`).

With the bar enabled, rendering a page containing either kind of block
throws, e.g.:

```
TypeError: Siteation\DebugBar\Plugin\View\BlockPlugin::aroundToHtml(): Return
value must be of type string, null returned in .../BlockPlugin.php:37
```

turning an otherwise harmless empty block into a 500 on the whole page. This
isn't limited to these two blocks — any block whose `_toHtml()` returns a
falsy, non-string value the normal, core-supported way trips it.

## Fix

Drop the return type declaration entirely (with a `@return string|false|null`
docblock instead), matching what core Magento's own `toHtml()` already
allows, rather than trying to enumerate every falsy value a block might
legitimately return.

## Testing

Reproduced against a Magento 2.4.8 / Hyvä store with Mirasvit's SEO module
installed: homepage 500s with the bar enabled (first on the Twitter Card
block returning null, then — after only widening to `?string` — on the
Searchbox block returning false), and renders correctly once the return type
is dropped entirely.